### PR TITLE
Make nexus an optional dependancy of jenkins_slave

### DIFF
--- a/jobs/jenkins-slave/spec
+++ b/jobs/jenkins-slave/spec
@@ -12,6 +12,7 @@ consumes:
   type: jenkins
 - name: nexus
   type: nexus
+  optional: true
 
 templates:
   bin/jenkins-slave_ctl: bin/jenkins-slave_ctl
@@ -37,11 +38,3 @@ properties:
     description: "Password of the user to connect to the master server"
   jenkins.slave.mode:
     description: "The mode to run the slave"
-  nexus.admin.username:
-    description: "Username of the nexus admin user"
-  nexus.admin.password:
-    description: "Password of nexus admin user"
-  nexus.deployer.username:
-    description: "Username of the nexus deployer user"
-  nexus.deployer.password:
-    description: "Password of nexus deployer user"

--- a/jobs/jenkins-slave/templates/config/settings.xml.erb
+++ b/jobs/jenkins-slave/templates/config/settings.xml.erb
@@ -1,14 +1,15 @@
 <settings>
+	<% if_link('nexus') do |nexus| %>
     <servers>
         <server>
-            <id>internal-releases</id>
-            <username><%= p("nexus.deployer.username") %></username>
-            <password><%= p("nexus.deployer.password") %></password>
+			<id>internal-releases</id>
+            <username><%= nexus.p("nexus.deployer.username") %></username>
+            <password><%= nexus.p("nexus.deployer.password") %></password>
         </server>
         <server>
             <id>internal-snapshots</id>
-            <username><%= p("nexus.deployer.username") %></username>
-            <password><%= p("nexus.deployer.password") %></password>
+            <username><%= nexus.p("nexus.deployer.username") %></username>
+            <password><%= nexus.p("nexus.deployer.password") %></password>
         </server>
     </servers>
 	<mirrors>
@@ -16,7 +17,7 @@
 			<!--This sends everything else to /public -->
 			<id>nexus-central</id>
 			<mirrorOf>*</mirrorOf>
-			<url>http://<%= link('nexus').instances[0].address %>:8081/repository/public/</url>
+			<url><%= "http://#{nexus.instances[0].address}:#{nexus.p('nexus.http.port')}/repository/public/" %></url>
 		</mirror>
 	</mirrors>
 	<profiles>
@@ -27,7 +28,7 @@
 			<repositories>
 				<repository>
 					<id>nexus-releases</id>
-					<url>http://<%= link('nexus').instances[0].address %>:8081/repository/releases</url>
+					<url><%= "http://#{nexus.instances[0].address}:#{nexus.p('nexus.http.port')}/repository/releases" %></url>
 					<releases>
 						<enabled>true</enabled>
 					</releases>
@@ -37,7 +38,7 @@
 				</repository>
 				<repository>
 					<id>nexus-snapshots</id>
-					<url>http://<%= link('nexus').instances[0].address %>:8081/repository/snapshots</url>
+					<url><%= "http://#{nexus.instances[0].address}:#{nexus.p('nexus.http.port')}/repository/snapshots" %></url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
@@ -74,4 +75,5 @@
 		<!--make the profile active all the time -->
 		<activeProfile>nexus</activeProfile>
 	</activeProfiles>
+	<% end %>
 </settings>


### PR DESCRIPTION
Also removes the nexus specific properties from the jenkins_slave config
Instead gets those properties from the nexus link accessor